### PR TITLE
Fix/fix bugs rendering owned projects

### DIFF
--- a/src/components/OwnedProjects.tsx
+++ b/src/components/OwnedProjects.tsx
@@ -38,7 +38,7 @@ const OwnedProjects = ({ walletAddress }: Props) => {
     setCountOwnedProjects(countOwnedProjectsResponse.data?.projects?.filter((project: { tokens: string | any[] }) => {
       return project.tokens.length > 0
     }).length)
-  }, [data, countOwnedProjectsResponse])
+  }, [JSON.stringify(data), JSON.stringify(filteredProjects), JSON.stringify(countOwnedProjectsResponse)])
 
   return (
     <Box>

--- a/src/hooks/useOwnedProjects.tsx
+++ b/src/hooks/useOwnedProjects.tsx
@@ -56,12 +56,9 @@ const ownedProjectsQuery = (walletAddress: string, { first, skip, orderDirection
       }
       minterConfiguration {
         basePrice
-        startPrice
         priceIsConfigured
         currencySymbol
         currencyAddress
-        startTime
-        endTime
       }
     }
   }`


### PR DESCRIPTION
GetProject query fails because it includes attributes not available on the schema.
The useEffect on the OwnedProjects page has object dependencies which can't be compared because it only checkes referential equality which will always be false. The solution I used was to cast them to strings for structural equality comparisons